### PR TITLE
v0.2.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: confMeta
 Title: Confidence Curves and P-Value Functions for Meta-Analysis
-Version: 0.2.2
+Version: 0.2.3
 Authors@R: c(
     person("Felix", "Hofmann", email = "felix.hofmann2@uzh.ch", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-3891-6239")),
     person("Leonhard", "Held", email = "leonhard.held@uzh.ch", role = c("aut"), comment = c(ORCID = "0000-0002-8686-5325"))

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include Makefile.defs
 
 PACKAGE = confMeta
-VERSION = 0.2.2
+VERSION = 0.2.3
 TAR = $(PACKAGE)_$(VERSION).tar.gz
 
 

--- a/R/autoplot_pfun.R
+++ b/R/autoplot_pfun.R
@@ -88,10 +88,17 @@ autoplot.confMeta <- function(
     if (!is.null(xlim)) {
         check_xlim(x = xlim)
     } else {
-        candidates <- c(
-            sapply(cms, "[[", i = "individual_cis"),
-            sapply(cms, "[[", i = "joint_cis"),
-            sapply(cms, "[[", i = "comparison_cis")
+
+        candidates <- unname(
+            do.call(
+                "c",
+                lapply(
+                    cms,
+                    function(x) {
+                        with(x, c(individual_cis, joint_cis, comparison_cis))
+                    }
+                )
+            )
         )
         ext_perc <- 5
         lower <- min(candidates)


### PR DESCRIPTION
This PR fixes an error that is caused by `sapply` unexpectedly returning a list instead of a numeric vector. 