### PR TITLE
Fix bug when specifying xlim arg in autoplot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: confMeta
 Title: Confidence Curves and P-Value Functions for Meta-Analysis
-Version: 0.3.3
+Version: 0.3.4
 Authors@R: c(
     person("Felix", "Hofmann", email = "felix@fshofmann.com",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-3891-6239")),

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include Makefile.defs
 
 PACKAGE = confMeta
-VERSION = 0.3.3
+VERSION = 0.3.4
 TAR = $(PACKAGE)_$(VERSION).tar.gz
 
 

--- a/R/autoplot_pfun.R
+++ b/R/autoplot_pfun.R
@@ -278,7 +278,7 @@ is_TF <- function(x) {
 }
 
 check_xlim <- function(x) {
-    ok <- length(x) == 2L && is.numeric(xlim) && xlim[1L] < xlim[2L]
+    ok <- length(x) == 2L && is.numeric(x) && x[1L] < x[2L]
     if (!ok) {
         stop(
             paste0(

--- a/man/autoplot.confMeta.Rd
+++ b/man/autoplot.confMeta.Rd
@@ -50,9 +50,11 @@ contains \code{"forest"} and will be ignored otherwise.}
 study effects are represented as drapery plots. If \code{FALSE} the studies
 are represented by a simple vertical line at their effect estimates.}
 
-\item{reference_methods}{A character vector of length 1, 2 or 3. Valid
-options are any combination of \code{c("fe", "re", "hk", "hc")}. Defaults to
-\code{c("fe", "re", "hk", "hc")}.}
+\item{reference_methods}{A character vector of length 1, 2, 3 or 4. Denotes
+the reference methods that should be shown in the plot. Valid options are
+any combination of \code{c("fe", "re", "hk", "hc")} which stand for fixed
+effect meta-analysis, random effects meta-analysis, Hartung-Knapp and
+Henmi-Copas. Defaults to \code{c("fe", "re", "hk", "hc")}.}
 
 \item{xlim}{Either NULL (default) or a numeric vector of length 2 which
 indicates the extent of the x-axis that should be shown.}


### PR DESCRIPTION
This PR fixes a bug in `autoplot()` when the argument `xlim` is user-specified.